### PR TITLE
Fix bug with long role names displaying incorrectly

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -74,8 +74,13 @@ p {
 .info_card p.role {
   font-size: 1vw;
   font-weight: 600;
-  display: inline;
+  display: inline-block;
   padding-left: 0.5vw;
+  max-width: 10vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0px;
 }
 
 .info_card p.country {


### PR DESCRIPTION
Role names that were too long were displayed incorrectly. Fixed by adding a max-width.

Other attributes have been tested. Long Names, countries and tech stack should all be handled correctly if the string is too long.