### PR TITLE
Add logic to truncate contributor names over 20 characters.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -53,7 +53,7 @@
       for (const contributor of contributors) {
         const username = contributor.github_username.trim();
         let name = contributor.name.trim();
-        if (name.length > 20) name = name.slice(0, 20);
+        if (name.length > 20) name = name.slice(0, 20) + '..';
         const stack = contributor.favorite_coding_stack.slice(0, 3);
 
         let about = contributor.about_me.trim();

--- a/src/index.html
+++ b/src/index.html
@@ -52,7 +52,8 @@
 
       for (const contributor of contributors) {
         const username = contributor.github_username.trim();
-        const name = contributor.name.trim();
+        let name = contributor.name.trim();
+        if (name.length > 20) name = name.slice(0, 20);
         const stack = contributor.favorite_coding_stack.slice(0, 3);
 
         let about = contributor.about_me.trim();


### PR DESCRIPTION
This PR addresses issue #333 by trimming contributor display names to a maximum of 20 characters.

If a contributor's name exceeds 20 characters, it is truncated and suffixed with .. (e.g., Alexander Montgomery Fitzgerald → Alexander Montgomery..).

This improves layout consistency and prevents name overflow on the contributor cards.

The change is implemented in the client-side rendering logic in the main HTML script block.

✔️ Verified visually to ensure correct behavior for long and short names.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Contributor names longer than 20 characters are now truncated with ".." for improved display in contributor cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->