### PR TITLE
ci: validate contributor entries on PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,6 @@
   - [ ] `github_username` (matches my GitHub handle)
   - [ ] `favorite_coding_stack` (at least one item)
   - [ ] `about_me` (a short bio)
-- [ ] If I added optional fields, they are non-empty:
   - [ ] `location` (e.g. `"City, Country"`)
   - [ ] `favorite_emoji` (e.g. `"🚀"`)
 - [ ] I ran `npm run lint:fix` and `npm run format:fix` locally.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Adding your contributor card? Make sure each box is ticked before submitting. -->
+
+## Checklist
+
+- [ ] My entry is **appended at the end** of `src/contributors.js` (not inserted mid-list).
+- [ ] All required fields are filled with non-empty values:
+  - [ ] `name`
+  - [ ] `github_username` (matches my GitHub handle)
+  - [ ] `favorite_coding_stack` (at least one item)
+  - [ ] `about_me` (a short bio)
+- [ ] If I added optional fields, they are non-empty:
+  - [ ] `location` (e.g. `"City, Country"`)
+  - [ ] `favorite_emoji` (e.g. `"🚀"`)
+- [ ] I ran `npm run lint:fix` and `npm run format:fix` locally.
+- [ ] I ran `npm run validate` locally and it printed `All entries are valid.`
+
+> The CI check **Validate contributors** must pass before this PR can be merged.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,3 +38,13 @@ jobs:
 
       - name: Format Check
         run: pnpm run format
+
+      - name: Validate contributors
+        run: |
+          if [ -n "${{ github.base_ref }}" ]; then
+            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+            node scripts/validate-contributors.mjs --base "origin/${{ github.base_ref }}"
+          else
+            git fetch --no-tags --depth=1 origin main || true
+            node scripts/validate-contributors.mjs --base origin/main
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ Learning playground for first-time open source contributors. Contributors open a
 - `npm start` — serve `src/` with live-server for local preview
 - `npm run lint` / `npm run lint:fix` — Biome lint (fix uses `--write --unsafe`)
 - `npm run format` / `npm run format:fix` — Biome format
+- `npm run validate` — diff-aware contributor entry validator (see below)
 
-CI (`.github/workflows/tests.yml`) only runs `pnpm run lint` and `pnpm run format` (the "Tests" name is a misnomer — there is no test suite). CI uses pnpm even though the README tells contributors to use npm; both work since the only state is `package.json`.
+CI (`.github/workflows/tests.yml`) runs lint, format, and `node scripts/validate-contributors.mjs --base origin/<base_ref>` on every PR. The "Tests" name is a misnomer — there is still no test suite. CI uses pnpm even though the README tells contributors to use npm; both work since the only state is `package.json`.
 
 ## Architecture
 
@@ -35,4 +36,10 @@ Page also includes:
 
 ## Reviewing contributor PRs
 
-A contributor entry is only accepted if all four fields are filled. `about_me` may be an empty string (the UI handles it), but per README all fields should be filled. Entries should be appended at the end of the array, not inserted mid-list, so the reverse-render order matches contribution order.
+A contributor entry is only accepted if all four required fields are filled. The `validate-contributors.mjs` script enforces this in CI:
+
+- It diffs against the PR's base ref (`--base origin/<base_ref>`). Entries whose `github_username` already exists in the base are **grandfathered**; entries whose handle is new in this PR get **strict** checks (including non-empty `about_me`).
+- Hard errors (block merge): missing required fields, wrong types, invalid GitHub handle on a new entry, duplicate handle when at least one side is new, malformed optional field.
+- Warnings (non-blocking): pre-existing duplicates or invalid handles in already-merged data — visible in CI output but don't fail the build.
+
+Entries must still be appended at the **end** of the array (not inserted mid-list) so the reverse-render order matches contribution order. The validator does not enforce ordering; reviewers do.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ CI (`.github/workflows/tests.yml`) runs lint, format, and `node scripts/validate
 Static site, no build step or framework:
 
 - `src/index.html` — page shell. The inline `<script type="module">` imports `contributors`, **reverses** the array (newest entries render first), and injects a card per entry by setting `innerHTML`. Avatar is fetched from `https://avatars.githubusercontent.com/<github_username>`.
-- `src/contributors.js` — single source of truth. Exports a `contributors` array of `{ name, github_username, favorite_coding_stack: string[], about_me: string, location?: string, favorite_emoji?: string }`. New contributors are appended to the **end** of this array. `location` and `favorite_emoji` are optional and the renderer omits them when missing.
+- `src/contributors.js` — single source of truth. Exports a `contributors` array of `{ name, github_username, favorite_coding_stack: string[], about_me: string, location: string, favorite_emoji: string }`. **All fields are required for new entries** (CI enforces this). New contributors are appended to the **end** of this array. The renderer still treats `location` and `favorite_emoji` defensively (omits them when missing) because most pre-existing entries were authored before these fields became required and are grandfathered.
 - `src/style.css` — plain CSS for the grid/card layout (Tailwind is in devDependencies but is **not currently wired into the page**).
 
 Rendering quirks to preserve when editing `index.html`:
@@ -36,10 +36,10 @@ Page also includes:
 
 ## Reviewing contributor PRs
 
-A contributor entry is only accepted if all four required fields are filled. The `validate-contributors.mjs` script enforces this in CI:
+A contributor entry is only accepted if all six required fields are filled. The `validate-contributors.mjs` script enforces this in CI:
 
-- It diffs against the PR's base ref (`--base origin/<base_ref>`). Entries whose `github_username` already exists in the base are **grandfathered**; entries whose handle is new in this PR get **strict** checks (including non-empty `about_me`).
-- Hard errors (block merge): missing required fields, wrong types, invalid GitHub handle on a new entry, duplicate handle when at least one side is new, malformed optional field.
+- It diffs against the PR's base ref (`--base origin/<base_ref>`). Entries whose `github_username` already exists in the base are **grandfathered** (presence and non-empty checks are skipped for them); entries whose handle is new in this PR get **strict** checks against every field.
+- Hard errors (block merge): missing required field on a new entry, wrong type, empty required field on a new entry, invalid GitHub handle on a new entry, duplicate handle when at least one side is new.
 - Warnings (non-blocking): pre-existing duplicates or invalid handles in already-merged data — visible in CI output but don't fail the build.
 
 Entries must still be appended at the **end** of the array (not inserted mid-list) so the reverse-render order matches contribution order. The validator does not enforce ordering; reviewers do.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install
 Now go to `src/contributors.js` file and add your details at the end of the file. \
 Please make sure to fill all the required fields. Else the pull request will not be accepted.
 
-Each entry looks like this:
+Each entry looks like this — **all fields are required**:
 
 ```js
 {
@@ -49,14 +49,10 @@ Each entry looks like this:
   github_username: "your-github-handle",
   favorite_coding_stack: ["JavaScript", "Python", "..."],
   about_me: "A short bio about yourself",
-  // Optional — feel free to add either or both:
   location: "City, Country",
   favorite_emoji: "🚀",
 }
 ```
-
-Required: `name`, `github_username`, `favorite_coding_stack`, `about_me`. \
-Optional: `location` (shown under your name on the card) and `favorite_emoji` (shown next to your name).
 
 ### 4. Format and validate your code.
 Run these commands to format the code and validate your entry. \

--- a/README.md
+++ b/README.md
@@ -58,14 +58,18 @@ Each entry looks like this:
 Required: `name`, `github_username`, `favorite_coding_stack`, `about_me`. \
 Optional: `location` (shown under your name on the card) and `favorite_emoji` (shown next to your name).
 
-### 4. Format your code.
-Run these two command to format and fix the code. \
-It will automatically fix the lint errors if any.
+### 4. Format and validate your code.
+Run these commands to format the code and validate your entry. \
+The first two will automatically fix lint/format errors if any. \
+The third checks that your new entry has every required field filled.
 
 ```bash
 npm run lint:fix
 npm run format:fix
+npm run validate
 ```
+
+> CI runs the same `npm run validate` check on every PR. If your new entry is missing a required field or duplicates an existing GitHub handle, the **Validate contributors** check will fail and the PR cannot be merged.
 
 ### 5. Push your new changess
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "biome lint .",
     "lint:fix": "biome lint --write --unsafe .",
     "format": "biome format .",
-    "format:fix": "biome format --write ."
+    "format:fix": "biome format --write .",
+    "validate": "node scripts/validate-contributors.mjs"
   },
   "author": "Rocktim Saikia",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "contribute-101",
   "private": true,
   "version": "2.0.0",
+  "type": "module",
   "description": "A simple project for the first time open source contributors",
   "scripts": {
     "start": "live-server src",

--- a/scripts/validate-contributors.mjs
+++ b/scripts/validate-contributors.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+const dataPath = resolve(root, "src/contributors.js");
+
+const REQUIRED = ["name", "github_username", "favorite_coding_stack", "about_me"];
+const OPTIONAL = ["location", "favorite_emoji"];
+const ALLOWED = new Set([...REQUIRED, ...OPTIONAL]);
+// GitHub handles: alphanumeric + single hyphens, cannot start or end with hyphen,
+// no consecutive hyphens, 1–39 characters.
+const USERNAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
+
+let contributors;
+try {
+  ({ contributors } = await import(dataPath));
+} catch (err) {
+  console.error("Could not import src/contributors.js — file is invalid JavaScript.");
+  console.error(err.message);
+  process.exit(1);
+}
+
+if (!Array.isArray(contributors)) {
+  console.error('src/contributors.js must export a "contributors" array.');
+  process.exit(1);
+}
+
+// Build the set of usernames that already exist in the base ref.
+// Anything missing from that set is treated as a NEW entry and gets strict checks
+// (including a non-empty `about_me`); previously merged entries are grandfathered.
+const baseFlagIdx = process.argv.indexOf("--base");
+const base = baseFlagIdx !== -1 ? process.argv[baseFlagIdx + 1] : "origin/main";
+
+let knownHandles = null;
+try {
+  const baseSource = execSync(`git show ${base}:src/contributors.js`, {
+    encoding: "utf8",
+    cwd: root,
+    stdio: ["pipe", "pipe", "ignore"],
+  });
+  knownHandles = new Set();
+  for (const m of baseSource.matchAll(/github_username:\s*"([^"]+)"/g)) {
+    knownHandles.add(m[1].toLowerCase());
+  }
+  console.log(
+    `Comparing against base "${base}" — ${knownHandles.size} known handles, ${contributors.length} on branch.`,
+  );
+} catch (_) {
+  console.log(
+    `Base ref "${base}" not available — treating every entry as new (strict mode).`,
+  );
+}
+
+const isNew = (handle) => {
+  if (knownHandles === null) return true;
+  if (!handle || typeof handle !== "string") return true;
+  return !knownHandles.has(handle.trim().toLowerCase());
+};
+
+const errors = [];
+const warnings = [];
+const seen = new Map();
+let newCount = 0;
+
+contributors.forEach((entry, idx) => {
+  const tag = `entry #${idx + 1}${
+    entry?.name
+      ? ` (${entry.name})`
+      : entry?.github_username
+        ? ` (@${entry.github_username})`
+        : ""
+  }`;
+
+  if (!entry || typeof entry !== "object") {
+    errors.push(`${tag}: must be an object`);
+    return;
+  }
+
+  const isNewEntry = isNew(entry.github_username);
+  if (isNewEntry) newCount++;
+
+  for (const field of REQUIRED) {
+    if (!(field in entry)) {
+      errors.push(`${tag}: missing required field "${field}"`);
+    }
+  }
+
+  if (typeof entry.name !== "string" || entry.name.trim() === "") {
+    errors.push(`${tag}: "name" must be a non-empty string`);
+  }
+
+  if (typeof entry.github_username !== "string" || entry.github_username.trim() === "") {
+    errors.push(`${tag}: "github_username" must be a non-empty string`);
+  } else {
+    const handle = entry.github_username.trim();
+    if (!USERNAME_RE.test(handle)) {
+      const msg = `${tag}: "github_username" "${handle}" is not a valid GitHub handle (letters, digits, hyphens; max 39 chars; no leading/trailing hyphen)`;
+      (isNewEntry ? errors : warnings).push(msg);
+    }
+    const lower = handle.toLowerCase();
+    if (seen.has(lower)) {
+      const prev = seen.get(lower);
+      const msg = `${tag}: duplicate github_username "${handle}" — already used at entry #${prev.idx + 1}`;
+      // A duplicate is only a hard error when at least one side is new in this PR
+      (isNewEntry || prev.isNew ? errors : warnings).push(msg);
+    } else {
+      seen.set(lower, { idx, isNew: isNewEntry });
+    }
+  }
+
+  if (
+    !Array.isArray(entry.favorite_coding_stack) ||
+    entry.favorite_coding_stack.length === 0
+  ) {
+    errors.push(`${tag}: "favorite_coding_stack" must be a non-empty array of strings`);
+  } else {
+    entry.favorite_coding_stack.forEach((tech, i) => {
+      if (typeof tech !== "string" || tech.trim() === "") {
+        errors.push(`${tag}: favorite_coding_stack[${i}] must be a non-empty string`);
+      }
+    });
+  }
+
+  if (typeof entry.about_me !== "string") {
+    errors.push(`${tag}: "about_me" must be a string`);
+  } else if (entry.about_me.trim() === "" && isNewEntry) {
+    errors.push(
+      `${tag}: "about_me" must be a non-empty string — please share a short bio about yourself`,
+    );
+  }
+
+  if ("location" in entry) {
+    if (typeof entry.location !== "string" || entry.location.trim() === "") {
+      errors.push(
+        `${tag}: "location" must be a non-empty string when present (or remove the field)`,
+      );
+    }
+  }
+
+  if ("favorite_emoji" in entry) {
+    if (typeof entry.favorite_emoji !== "string" || entry.favorite_emoji.trim() === "") {
+      errors.push(
+        `${tag}: "favorite_emoji" must be a non-empty string when present (or remove the field)`,
+      );
+    }
+  }
+
+  for (const key of Object.keys(entry)) {
+    if (!ALLOWED.has(key)) {
+      warnings.push(
+        `${tag}: unknown field "${key}" — allowed fields are: ${[...ALLOWED].join(", ")}`,
+      );
+    }
+  }
+});
+
+console.log(
+  `Checked ${contributors.length} contributors (${newCount} new in this branch).`,
+);
+
+if (warnings.length > 0) {
+  console.log(`\n${warnings.length} warning(s):`);
+  for (const w of warnings) console.log(`  - ${w}`);
+}
+
+if (errors.length > 0) {
+  console.error(`\n${errors.length} error(s):`);
+  for (const e of errors) console.error(`  - ${e}`);
+  console.error(
+    "\nPlease fix the above before this PR can be merged. " +
+      "See README.md for the contributor entry format.",
+  );
+  process.exit(1);
+}
+
+console.log("All entries are valid.");

--- a/scripts/validate-contributors.mjs
+++ b/scripts/validate-contributors.mjs
@@ -7,9 +7,15 @@ const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
 const dataPath = resolve(root, "src/contributors.js");
 
-const REQUIRED = ["name", "github_username", "favorite_coding_stack", "about_me"];
-const OPTIONAL = ["location", "favorite_emoji"];
-const ALLOWED = new Set([...REQUIRED, ...OPTIONAL]);
+const REQUIRED = [
+  "name",
+  "github_username",
+  "favorite_coding_stack",
+  "about_me",
+  "location",
+  "favorite_emoji",
+];
+const ALLOWED = new Set(REQUIRED);
 // GitHub handles: alphanumeric + single hyphens, cannot start or end with hyphen,
 // no consecutive hyphens, 1–39 characters.
 const USERNAME_RE = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
@@ -82,9 +88,13 @@ contributors.forEach((entry, idx) => {
   const isNewEntry = isNew(entry.github_username);
   if (isNewEntry) newCount++;
 
-  for (const field of REQUIRED) {
-    if (!(field in entry)) {
-      errors.push(`${tag}: missing required field "${field}"`);
+  // Presence is enforced strictly for new entries only; entries that already
+  // exist on the base ref are grandfathered (they may pre-date a field).
+  if (isNewEntry) {
+    for (const field of REQUIRED) {
+      if (!(field in entry)) {
+        errors.push(`${tag}: missing required field "${field}"`);
+      }
     }
   }
 
@@ -133,18 +143,18 @@ contributors.forEach((entry, idx) => {
   }
 
   if ("location" in entry) {
-    if (typeof entry.location !== "string" || entry.location.trim() === "") {
-      errors.push(
-        `${tag}: "location" must be a non-empty string when present (or remove the field)`,
-      );
+    if (typeof entry.location !== "string") {
+      errors.push(`${tag}: "location" must be a string`);
+    } else if (entry.location.trim() === "" && isNewEntry) {
+      errors.push(`${tag}: "location" must be a non-empty string (e.g. "City, Country")`);
     }
   }
 
   if ("favorite_emoji" in entry) {
-    if (typeof entry.favorite_emoji !== "string" || entry.favorite_emoji.trim() === "") {
-      errors.push(
-        `${tag}: "favorite_emoji" must be a non-empty string when present (or remove the field)`,
-      );
+    if (typeof entry.favorite_emoji !== "string") {
+      errors.push(`${tag}: "favorite_emoji" must be a string`);
+    } else if (entry.favorite_emoji.trim() === "" && isNewEntry) {
+      errors.push(`${tag}: "favorite_emoji" must be a non-empty string (e.g. "🚀")`);
     }
   }
 


### PR DESCRIPTION
Adds a diff-aware validator (`scripts/validate-contributors.mjs`) wired into CI and a PR template so new contributor entries with missing required fields, invalid GitHub handles, or duplicate usernames fail the `Validate contributors` check and cannot be merged, while pre-existing data quality issues are surfaced as non-blocking warnings.